### PR TITLE
Adds the ee-10 variant for WF 40 Beta1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 env:
-  WILDFLY_GLOW: https://github.com/wildfly/wildfly-glow/releases/download/2.0.0.Beta1/wildfly-glow-2.0.0.Beta1.zip
+  WILDFLY_GLOW: https://github.com/wildfly/wildfly-glow/releases/download/2.0.0.Beta2/wildfly-glow-2.0.0.Beta2.zip
 jobs:
   build:
     name: ${{ matrix.os }}-jdk${{ matrix.java }}

--- a/.github/workflows/snapshot-ci.yml
+++ b/.github/workflows/snapshot-ci.yml
@@ -11,7 +11,7 @@ on:
       - 'release'
     types: [opened, synchronize, reopened, ready_for_review]
 env:
-  WILDFLY_GLOW: https://github.com/wildfly/wildfly-glow/releases/download/2.0.0.Beta1/wildfly-glow-2.0.0.Beta1.zip
+  WILDFLY_GLOW: https://github.com/wildfly/wildfly-glow/releases/download/2.0.0.Beta2/wildfly-glow-2.0.0.Beta2.zip
 jobs:
   build:
     name: ${{ matrix.os }}-jdk${{ matrix.java }}

--- a/40.0.0.Beta1-SNAPSHOT/ee-10/provisioning-bare-metal.xml
+++ b/40.0.0.Beta1-SNAPSHOT/ee-10/provisioning-bare-metal.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<installation xmlns="urn:jboss:galleon:provisioning:3.0">
+    <feature-pack location="org.wildfly:wildfly-ee-10-feature-pack:40.0.0.Beta1-SNAPSHOT"/>
+    <feature-pack location="org.wildfly:wildfly-galleon-pack:40.0.0.Beta1-SNAPSHOT"/>
+    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:11.3.0.Final"/>
+    <feature-pack location="org.wildfly.extras.grpc:wildfly-grpc-feature-pack:0.1.16.Final"/>
+    <feature-pack location="org.wildfly.security.vault:wildfly-vault-feature-pack:1.0.0.Alpha6"/>
+ 
+    <options>
+      <option name="required_feature_packs" value="org.wildfly:wildfly-galleon-pack:"/>
+    </options>
+</installation>

--- a/40.0.0.Beta1-SNAPSHOT/ee-10/provisioning-cloud.xml
+++ b/40.0.0.Beta1-SNAPSHOT/ee-10/provisioning-cloud.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<installation xmlns="urn:jboss:galleon:provisioning:3.0">
+    <feature-pack location="org.wildfly:wildfly-ee-10-feature-pack:40.0.0.Beta1-SNAPSHOT"/>
+    <feature-pack location="org.wildfly:wildfly-galleon-pack:40.0.0.Beta1-SNAPSHOT"/>
+    <feature-pack location="org.wildfly.cloud:wildfly-cloud-galleon-pack:9.2.1.Final"/>
+    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:11.3.0.Final"/>
+    <feature-pack location="org.wildfly.extras.grpc:wildfly-grpc-feature-pack:0.1.16.Final"/>
+    <feature-pack location="org.wildfly.security.vault:wildfly-vault-feature-pack:1.0.0.Alpha6"/>
+
+    <options>
+      <option name="required_feature_packs" value="org.wildfly:wildfly-galleon-pack:"/>
+    </options>
+</installation>

--- a/40.0.0.Beta1-SNAPSHOT/variants.json
+++ b/40.0.0.Beta1-SNAPSHOT/variants.json
@@ -3,6 +3,11 @@
             "name": "preview",
             "directory": "tech-preview",
             "description": "WildFly Preview"
+        },
+        {
+            "name": "ee-10",
+            "directory": "ee-10",
+            "description": "WildFly EE 10"
         }
         
 ]}

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -47,7 +47,7 @@
       </developer>
     </developers>
     <properties>
-        <version.org.wildfly.glow>2.0.0.Beta1</version.org.wildfly.glow>
+        <version.org.wildfly.glow>2.0.0.Beta2</version.org.wildfly.glow>
         <version.gpg.plugin>3.2.8</version.gpg.plugin>
         <version.nxrm3.plugin>1.0.7</version.nxrm3.plugin>
         <!-- maven-gpg-plugin -->

--- a/spaces/incubating/40.0.0.Beta1-SNAPSHOT/ee-10/provisioning-bare-metal.xml
+++ b/spaces/incubating/40.0.0.Beta1-SNAPSHOT/ee-10/provisioning-bare-metal.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<installation xmlns="urn:jboss:galleon:provisioning:3.0">
+    <feature-pack location="org.wildfly.generative-ai:wildfly-ai-feature-pack:0.9.1"/>
+</installation>

--- a/spaces/incubating/40.0.0.Beta1-SNAPSHOT/ee-10/provisioning-cloud.xml
+++ b/spaces/incubating/40.0.0.Beta1-SNAPSHOT/ee-10/provisioning-cloud.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<installation xmlns="urn:jboss:galleon:provisioning:3.0">
+    <feature-pack location="org.wildfly.generative-ai:wildfly-ai-feature-pack:0.9.1"/>
+</installation>

--- a/tests/run-wildfly-glow-tests.sh
+++ b/tests/run-wildfly-glow-tests.sh
@@ -19,7 +19,7 @@ function test {
   provisioningFile=$4
   addOns=$5
   context=$6
-  preview=$7
+  variant=$7
   spaces=$8
   test_count=$((test_count+1))
 
@@ -39,19 +39,19 @@ fi
 if [ ! -z "$context" ]; then
   context="--$context";
 fi
-if [ ! -z "$preview" ]; then
-  preview="--wildfly-preview";
+if [ ! -z "$variant" ]; then
+  variant="--server-variant=$variant";
 fi
 if [ ! -z "$spaces" ]; then
   spaces="--spaces=$spaces";
 fi
 if [ ! -z $GENERATE_CONFIG ]; then
- echo "java -jar -Dverbose=true $JAVA_OPTS $jar scan $warFile ${provisioningFile} $profile $addOns $preview $serverVersionOption $spaces"
- java -Dverbose=true $JAVA_OPTS -jar $jar scan $warFile ${provisioningFile} $profile $addOns $preview $serverVersionOption $spaces
+ echo "java -jar -Dverbose=true $JAVA_OPTS $jar scan $warFile ${provisioningFile} $profile $addOns $variant $serverVersionOption $spaces"
+ java -Dverbose=true $JAVA_OPTS -jar $jar scan $warFile ${provisioningFile} $profile $addOns $variant $serverVersionOption $spaces
 else
 
   if [ "$DEBUG" = 1 ]; then
-    echo "java $JAVA_OPTS $compact -jar $jar scan $warFile ${provisioningFile} $profile $addOns $context $preview $serverVersionOption $spaces"
+    echo "java $JAVA_OPTS $compact -jar $jar scan $warFile ${provisioningFile} $profile $addOns $context $variant $serverVersionOption $spaces"
   fi
 
   found_layers=$(java $JAVA_OPTS $compact  -jar $jar scan \
@@ -60,8 +60,8 @@ else
   $profile \
   $addOns \
   $context \
-  $preview \
-  $serverVersionOption\
+  $variant \
+  $serverVersionOption \
   $spaces)
 
   if [ "$found_layers" != "$expected" ]; then
@@ -76,7 +76,7 @@ else
   $profile \
   $addOns \
   $context \
-  $preview --provision=SERVER --fails-on-error=false \
+  $variant --provision=SERVER --fails-on-error=false \
   $serverVersionOption \
   $spaces
   if [ $? -ne 0 ]; then
@@ -92,7 +92,7 @@ else
   $profile \
   $addOns \
   $context \
-  $preview --provision=BOOTABLE_JAR --fails-on-error=false \
+  $variant --provision=BOOTABLE_JAR --fails-on-error=false \
   $serverVersionOption \
   $spaces
   if [ $? -ne 0 ]; then
@@ -161,7 +161,7 @@ test \
 "" \
 "" \
 cloud \
-"true"
+"preview"
 
 echo kitchensink cloud HA
 test \
@@ -171,6 +171,27 @@ test \
 "" \
 "" \
 cloud
+
+echo kitchensink EE-10
+test \
+"[bean-validation, cdi, ee-integration, ejb-lite, h2-driver, jaxrs, jpa, jsf]==>ee-core-profile-server,ejb-lite,h2-driver,jaxrs,jpa,jsf" \
+"$WILDFLY_GLOW_DIR/examples/kitchensink.war" \
+"" \
+"" \
+"" \
+"" \
+"ee-10"
+
+
+echo kitchensink cloud EE-10
+test \
+"[bean-validation, cdi, ee-integration, ejb-lite, h2-driver, jaxrs, jpa, jsf]==>ee-core-profile-server,ejb-lite,h2-driver,jaxrs,jpa,jsf" \
+"$WILDFLY_GLOW_DIR/examples/kitchensink.war" \
+"" \
+"" \
+"" \
+cloud \
+"ee-10"
 
 ### Extra feature-packs testing
 
@@ -192,7 +213,7 @@ test \
 "" \
 "grpc" \
 "" \
-"true"
+"preview"
 
 echo kitchensink + hashicorp-vault
 test \
@@ -211,7 +232,7 @@ test \
 "" \
 "hashicorp-vault" \
 "" \
-"true"
+"preview"
 
 
 echo graphql
@@ -236,7 +257,7 @@ test \
 "" \
 "postgresql" \
 "" \
-"true"
+"preview"
 
 echo saml auto-registration
 test \
@@ -277,7 +298,7 @@ test \
 "" \
 "" \
 "" \
-"true" \
+"preview" \
 incubating
 
 echo Incubating ai feature-pack with opentelemetry support.


### PR DESCRIPTION
* The EE-10 variant for WildFly 40.0.0.Beta1-SNAPSHOT
* The test with the SNAPSHOT build of wildfly (that contains the ee-10 variant) have been run locally, the nightly download doesn't already contains the ee-10 variant.
* In the test the preview flag has been replaced by the "preview" variant.